### PR TITLE
Fix docs.py run

### DIFF
--- a/openprocurement/contracting/api/tests/tests.ini
+++ b/openprocurement/contracting/api/tests/tests.ini
@@ -13,6 +13,7 @@ pyramid.debug_routematch = false
 pyramid.debug_templates = true
 pyramid.default_locale_name = en
 plugins = api,tender_core,belowThreshold,contracting
+update_after = False
 
 [server:main]
 use = egg:chaussette


### PR DESCRIPTION
Падают тесты в doc.py из-за того что вьюха не обновлена, не знаю, как оно раньше работало. 